### PR TITLE
♻️ Refactor: 리뷰 섹션 리팩토링

### DIFF
--- a/src/widgets/review/api/useReviewListQuery.ts
+++ b/src/widgets/review/api/useReviewListQuery.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { fetchReviewList } from './fetchReviewList';
 import { queryKeys } from '@/shared/apis/queryKeys';
 import type { ReviewListQueryParams, ReviewListResponse } from '@/shared/types/review';
@@ -6,7 +6,7 @@ import type { ReviewListQueryParams, ReviewListResponse } from '@/shared/types/r
 const INITIAL_PAGE = 1;
 
 export const useReviewListQuery = (params?: ReviewListQueryParams) =>
-  useInfiniteQuery<ReviewListResponse>({
+  useSuspenseInfiniteQuery<ReviewListResponse>({
     queryKey: queryKeys.REVIEWS(params),
     initialPageParam: INITIAL_PAGE,
     queryFn: ({ pageParam }) => {

--- a/src/widgets/review/ui/ReviewSection.tsx
+++ b/src/widgets/review/ui/ReviewSection.tsx
@@ -39,7 +39,7 @@ const ReviewSection = ({ onClickMore }: ReviewSectionProps) => {
   const sentinelRef = useIntersectionObserver<HTMLDivElement>({
     onIntersect: handleIntersect,
     enabled: canFetchMore,
-    rootMargin: '100px 0px',
+    rootMargin: '400px 0px',
   });
 
   // 더보기 버튼 클릭 시 무한 스크롤 모드로 전환

--- a/src/widgets/review/ui/ReviewSection.tsx
+++ b/src/widgets/review/ui/ReviewSection.tsx
@@ -21,11 +21,11 @@ const renderSkeletons = (count: number, prefix: string) =>
   ));
 
 const ReviewSection = ({ onClickMore }: ReviewSectionProps) => {
-  const { data, isLoading, isError, fetchNextPage, isFetchingNextPage } = useReviewListQuery();
+  const { data, fetchNextPage, isFetchingNextPage } = useReviewListQuery();
   const [isInfiniteMode, setInfiniteMode] = useState(false);
 
   const lastPage = data?.pages.at(-1);
-  const reviews: ReviewCardProps[] = data?.pages.flatMap((page) => page.data.content) ?? [];
+  const reviews: ReviewCardProps[] = data.pages.flatMap((page) => page.data.content) ?? [];
   const skeletonCount = lastPage?.data.content.length ?? DEFAULT_SKELETON_COUNT;
   const canFetchMore = isInfiniteMode && (lastPage?.data.hasNext ?? false);
   const nextPageIndex = data?.pages.length ?? 1;
@@ -49,19 +49,6 @@ const ReviewSection = ({ onClickMore }: ReviewSectionProps) => {
     onClickMore?.();
   };
 
-  if (isError) return null;
-
-  const renderLoading = () =>
-    isLoading ? (
-      <section className={s.section}>
-        <Deferred active={isLoading}>
-          <div className={s.grid} aria-label='리뷰 로딩 중'>
-            {renderSkeletons(skeletonCount, 'initial-skeleton')}
-          </div>
-        </Deferred>
-      </section>
-    ) : null;
-
   const renderContent = () => (
     <section className={s.section}>
       <div className={s.grid}>
@@ -82,8 +69,6 @@ const ReviewSection = ({ onClickMore }: ReviewSectionProps) => {
       {canFetchMore && <div ref={sentinelRef} className={s.sentinel} aria-hidden />}
     </section>
   );
-
-  if (isLoading) return renderLoading();
 
   return renderContent();
 };


### PR DESCRIPTION
# 🏡 Pull requests
### 📍 작업한 이슈번호
- #68 

### ✏️ 작업한 내용
**리뷰 섹션 Suspense 적용**
- 리뷰 리스트 훅을 `useInfiniteQuery`에서 `useSuspenseInfiniteQuery`로 전환해 초기 로딩을 Suspense에서 처리하도록 리팩토링했어요.
- 기존의 isLoading, isError 기반 분기와 초기 스켈레톤은 FetchBoundary fallback과 중복되기 때문에 제거했고 리뷰 섹션에서는 추가 페이지 로딩만 isFetchingNextPage로 관리해 더보기 버튼을 누른 이후에만 스켈레톤이 노출되도록 단순화했어요.
```ts
export const useReviewListQuery = (params?: ReviewListQueryParams) =>
  useSuspenseInfiniteQuery({
    queryKey: queryKeys.REVIEWS(params),
    initialPageParam: 1,
    queryFn: ({ pageParam }) => fetchReviewList({ ...params, page: pageParam }),
    getNextPageParam: (lastPage, pages) =>
      lastPage.data.hasNext ? pages.length + 1 : undefined,
  });
```
```ts
const { data, fetchNextPage, isFetchingNextPage } = useReviewListQuery();

<Deferred active={isFetchingNextPage}>
  {renderSkeletons(skeletonCount, `page-${nextPageIndex}-skeleton`)}
</Deferred>
```

**무한 스크롤 UX 개선**
- 무한 스크롤 전환 시 이미지 로딩 지연이 있어서 Intersection Observer의 rootMargin을 400px로 확장해 다음 페이지의 fetch 시점을 앞당겼어요.

## 🛠️ PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가 또는 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 💬 리뷰 요청사항
- Suspense 전환 후 로딩 흐름이 괜찮은지 확인 부탁드립니다!